### PR TITLE
Ajustando posição do texto que contém as aspas

### DIFF
--- a/src/util/eta-quill/eta-quill.ts
+++ b/src/util/eta-quill/eta-quill.ts
@@ -318,14 +318,16 @@ export class EtaQuill extends Quill {
     if (this._linhaAtual) {
       let index: number = this.inicioConteudoAtual;
       const texto: string = this.getText(index, this.linhaAtual?.blotConteudo.tamanho) ?? '';
+      let posicaoTexto = index;
 
       if (texto.indexOf('"') > -1) {
         for (let i = 0; i < texto.length; i++) {
           if (texto[i] === '"') {
-            index += i;
-            this.deleteText(index, 1, Quill.sources.SILENT);
-            this.insertText(index, this.aspasAberta ? '”' : '“', Quill.sources.SILENT);
+            posicaoTexto += i;
+            this.deleteText(posicaoTexto, 1, Quill.sources.SILENT);
+            this.insertText(posicaoTexto, this.aspasAberta ? '”' : '“', Quill.sources.SILENT);
             this.aspasAberta = !this.aspasAberta;
+            posicaoTexto = index;
           }
         }
       }


### PR DESCRIPTION
- Cria a variável "posicaoTexto" que inicializa com o valor de "index", em cada ocorrência das aspas, pega a posição , substitui por aspas curvas e reinicializa a "posicaoTexto" com o valor de "index".  
- Evita que o valor de "index" escape de dentro do tamanho do texto.