### PR TITLE
Desabilitar arrastar soltar

### DIFF
--- a/src/util/eta-quill/eta-clipboard.ts
+++ b/src/util/eta-quill/eta-clipboard.ts
@@ -23,14 +23,6 @@ export class EtaClipboard extends Clipboard {
         this.onChange.notify('clipboard');
       }
     });
-
-    this.quill.root.addEventListener('dragstart', (e) => {
-      e.preventDefault();
-    });
-
-    this.quill.root.addEventListener('drop', (e) => {
-      e.preventDefault();
-    });
   }
 
   convert(html?: any): DeltaStatic {

--- a/src/util/eta-quill/eta-clipboard.ts
+++ b/src/util/eta-quill/eta-clipboard.ts
@@ -23,6 +23,14 @@ export class EtaClipboard extends Clipboard {
         this.onChange.notify('clipboard');
       }
     });
+
+    this.quill.root.addEventListener('dragstart', (e) => {
+      e.preventDefault();
+    });
+
+    this.quill.root.addEventListener('drop', (e) => {
+      e.preventDefault();
+    });
   }
 
   convert(html?: any): DeltaStatic {

--- a/src/util/eta-quill/eta-quill.ts
+++ b/src/util/eta-quill/eta-quill.ts
@@ -134,6 +134,12 @@ export class EtaQuill extends Quill {
     this.on('text-change', this.onTextChange);
     this.on('selection-change', this.onSelectionChange);
     this.buffer = new EtaQuillBuffer(bufferHtml, {});
+    this.root.addEventListener('dragstart', (e) => {
+      e.preventDefault();
+    });
+    this.root.addEventListener('drop', (e) => {
+      e.preventDefault();
+    });
   }
 
   destroi(): void {


### PR DESCRIPTION
 Essa alteração desabilita os eventos "dragstart" e "drop" dentro do editor.