### PR TITLE
alterando link da norma alterada de lexml.gov.br para o normas.leg.br

### DIFF
--- a/src/components/editor/editor.component.ts
+++ b/src/components/editor/editor.component.ts
@@ -345,7 +345,7 @@ export class EditorComponent extends connect(rootStore)(LitElement) {
     const linkTooltip = document.querySelector('a.ql-preview');
     const href = linkTooltip?.getAttribute('href');
     if (href?.startsWith('urn')) {
-      const url = 'https://www.lexml.gov.br/urn/' + href;
+      const url = 'https://normas.leg.br/?urn=' + href;
       linkTooltip!.setAttribute('href', url);
       linkTooltip!.innerHTML = getNomeExtenso(href);
     }


### PR DESCRIPTION
Altera o endereçodo link de norma alterada para o normas.leg.br