### PR TITLE
esconde input que aparece antes do editor

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -22,10 +22,6 @@
         -webkit-box-shadow: 0px;
         box-shadow: none;
       }
-
-      .ql-snow .ql-hidden {
-        display: none;
-      }
     </style>
   </head>
 

--- a/demo/index.html
+++ b/demo/index.html
@@ -22,6 +22,10 @@
         -webkit-box-shadow: 0px;
         box-shadow: none;
       }
+
+      .ql-snow .ql-hidden {
+        display: none;
+      }
     </style>
   </head>
 

--- a/src/components/editor/editor.component.ts
+++ b/src/components/editor/editor.component.ts
@@ -245,6 +245,10 @@ export class EditorComponent extends connect(rootStore)(LitElement) {
           right: 0;
         }
 
+        .ql-snow .ql-hidden {
+          display: none;
+        }
+
         .ql-snow .ql-tooltip::before {
           content: 'Acesse a norma:';
         }


### PR DESCRIPTION
esconde input criado pelo quill/themes/snow.js(linhas 72-77), dentro da classe .ql-hidden, no editor.components.ts