### PR TITLE
QuillJS especificar formatos

### DIFF
--- a/src/components/editor/editor.component.ts
+++ b/src/components/editor/editor.component.ts
@@ -809,6 +809,7 @@ export class EditorComponent extends connect(rootStore)(LitElement) {
 
   private configEditor(): QuillOptionsStatic {
     return {
+      formats: ['bold', 'italic', 'link', 'underline', 'strike'],
       modules: {
         toolbar: {
           container: '#lx-eta-barra-ferramenta',

--- a/src/components/justificativa/justificativa.component.ts
+++ b/src/components/justificativa/justificativa.component.ts
@@ -63,6 +63,7 @@ export class JustificativaEmendaComponent extends LitElement {
     this.container = document.querySelector('#editor-justificativa');
     if (this.container) {
       this.quill = new Quill(this.container as HTMLElement, {
+        formats: ['bold', 'italic', 'link', 'underline', 'strike'],
         modules: {
           toolbar: {
             container: this.toolbarOptions,

--- a/src/util/eta-quill/eta-clipboard.ts
+++ b/src/util/eta-quill/eta-clipboard.ts
@@ -50,4 +50,29 @@ export class EtaClipboard extends Clipboard {
     this.container.innerHTML = '';
     return delta;
   }
+
+  onPaste(e: ClipboardEvent): void {
+    e.preventDefault();
+    const range = this.quill.getSelection();
+    const html = e?.clipboardData?.getData('text/html');
+    const parser = new DOMParser().parseFromString(html!, 'text/html');
+    let text = '';
+    const allowedTags = ['A', 'B', 'STRONG', 'S', 'U', 'I', 'EM'];
+    const walkDOM = (node, func) => {
+      func(node);
+      node = node.firstChild;
+      while (node) {
+        walkDOM(node, func);
+        node = node.nextSibling;
+      }
+    };
+    walkDOM(parser, function (node) {
+      if (allowedTags.includes(node.tagName)) {
+        text += node.outerHTML;
+      } else if (node.nodeType === 3 && !allowedTags.includes(node.parentElement.tagName)) {
+        text += node.nodeValue;
+      }
+    });
+    this.quill.clipboard.dangerouslyPasteHTML(range.index, text);
+  }
 }


### PR DESCRIPTION
Corrige o evento de colar para aceitar somente tags html permitidas.