### PR TITLE
#117 cria função que desmarca dispositivos no editor

### DIFF
--- a/src/util/eta-quill/eta-quill.ts
+++ b/src/util/eta-quill/eta-quill.ts
@@ -255,6 +255,13 @@ export class EtaQuill extends Quill {
     }, 0);
   }
 
+  private desmarcarLinhas(): void {
+    document.querySelectorAll('.container__elemento--ativo').forEach(elemento => {
+      const linha = this.getLinhaPorId(parseInt(elemento.id.substr(7), 0));
+      linha.desativarBorda();
+    });
+  }
+
   private verificarMudouLinha(range: RangeStatic, oldRange?: RangeStatic): boolean {
     // correção bug: cursor se perde ao teclar ↑ na primeira linha
     if (oldRange && range?.index === 0 && range?.length === 0) {
@@ -284,9 +291,9 @@ export class EtaQuill extends Quill {
           if (linhaCursor === linhaCursorAnt) {
             return false;
           }
-          this.desmarcarLinhaAtual(linhaCursorAnt);
         }
       }
+      this.desmarcarLinhas();
       this.marcarLinhaAtual(linhaCursor);
       return true;
     }


### PR DESCRIPTION
Cria função desmarcarLinhas(),  que é chamada antes do click outro elemento. Soluciona os seguintes bugs:

- Não desativar o elemento anterior , após o click fora do editor;
- Não desativar o elemento anterior,  após abrir um arquivo com emenda;  
